### PR TITLE
Introducing OperatorStateMetadataV2 for the TransformWithState operator

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -183,6 +183,14 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   def requiredChildOrdering: Seq[Seq[SortOrder]] = Seq.fill(children.size)(Nil)
 
   /**
+   * This method will be called at the end of a MicrobatchExecution
+   * to write the metadata of the operator to the checkpoint file.
+   */
+  def writeOperatorStateMetadata(): Unit = {
+    children.foreach(_.writeOperatorStateMetadata())
+  }
+
+  /**
    * Returns the result of this query as an RDD[InternalRow] by delegating to `doExecute` after
    * preparations.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
@@ -47,14 +47,13 @@ case class StateMetadataTableEntry(
     numPartitions: Int,
     minBatchId: Long,
     maxBatchId: Long,
-    numColsPrefixKey: Int,
-    operatorProperties: Map[String, String] = Map.empty[String, String]) {
+    operatorProperties: Map[String, String],
+    numColsPrefixKey: Int) {
   def toRow(): InternalRow = {
     // create MapData from Map
     val mapData: MapData = ArrayBasedMapData.apply(
       operatorProperties.keys.map(UTF8String.fromString).toArray,
-      operatorProperties.values.map(UTF8String.fromString).toArray
-    )
+      operatorProperties.values.map(UTF8String.fromString).toArray)
 
     new GenericInternalRow(
       Array[Any](operatorId,
@@ -63,7 +62,6 @@ case class StateMetadataTableEntry(
         numPartitions,
         minBatchId,
         maxBatchId,
-        numColsPrefixKey,
         mapData))
   }
 }
@@ -77,7 +75,6 @@ object StateMetadataTableEntry {
       .add("numPartitions", IntegerType)
       .add("minBatchId", LongType)
       .add("maxBatchId", LongType)
-      .add("numColsPrefixKey", IntegerType)
       .add("operatorProperties", MapType(StringType, StringType, valueContainsNull = false))
   }
 }
@@ -220,6 +217,7 @@ class StateMetadataPartitionReader(
               stateStoreMetadata.numPartitions,
               if (batchIds.nonEmpty) batchIds.head else -1,
               if (batchIds.nonEmpty) batchIds.last else -1,
+              Map.empty[String, String],
               stateStoreMetadata.numColsPrefixKey
             )
           }
@@ -231,8 +229,8 @@ class StateMetadataPartitionReader(
               stateStoreMetadata.numPartitions,
               if (batchIds.nonEmpty) batchIds.head else -1,
               if (batchIds.nonEmpty) batchIds.last else -1,
-              stateStoreMetadata.numColsPrefixKey,
-              v2.operatorProperties
+              v2.operatorProperties,
+              stateStoreMetadata.numColsPrefixKey
             )
           }
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
@@ -46,10 +46,9 @@ case class StateMetadataTableEntry(
     numPartitions: Int,
     minBatchId: Long,
     maxBatchId: Long,
-    operatorProperties: String,
+    operatorPropertiesJson: String,
     numColsPrefixKey: Int) {
   def toRow(): InternalRow = {
-
     new GenericInternalRow(
       Array[Any](operatorId,
         UTF8String.fromString(operatorName),
@@ -57,7 +56,7 @@ case class StateMetadataTableEntry(
         numPartitions,
         minBatchId,
         maxBatchId,
-        UTF8String.fromString(operatorProperties),
+        UTF8String.fromString(operatorPropertiesJson),
         numColsPrefixKey
       ))
   }
@@ -226,7 +225,7 @@ class StateMetadataPartitionReader(
               stateStoreMetadata.numPartitions,
               if (batchIds.nonEmpty) batchIds.head else -1,
               if (batchIds.nonEmpty) batchIds.last else -1,
-              v2.operatorProperties,
+              v2.operatorPropertiesJson,
               stateStoreMetadata.numColsPrefixKey
             )
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
@@ -57,7 +57,9 @@ case class StateMetadataTableEntry(
         numPartitions,
         minBatchId,
         maxBatchId,
-        UTF8String.fromString(operatorProperties)))
+        UTF8String.fromString(operatorProperties),
+        numColsPrefixKey
+      ))
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
@@ -204,31 +204,20 @@ class StateMetadataPartitionReader(
   private[state] lazy val stateMetadata: Iterator[StateMetadataTableEntry] = {
     allOperatorStateMetadata.flatMap { operatorStateMetadata =>
       require(operatorStateMetadata.version == 1 || operatorStateMetadata.version == 2)
-      operatorStateMetadata match {
-        case v1: OperatorStateMetadataV1 =>
-          v1.stateStoreInfo.map { stateStoreMetadata =>
-            StateMetadataTableEntry(v1.operatorInfo.operatorId,
-              v1.operatorInfo.operatorName,
-              stateStoreMetadata.storeName,
-              stateStoreMetadata.numPartitions,
-              if (batchIds.nonEmpty) batchIds.head else -1,
-              if (batchIds.nonEmpty) batchIds.last else -1,
-              "",
-              stateStoreMetadata.numColsPrefixKey
-            )
-          }
-        case v2: OperatorStateMetadataV2 =>
-          v2.stateStoreInfo.map { stateStoreMetadata =>
-            StateMetadataTableEntry(v2.operatorInfo.operatorId,
-              v2.operatorInfo.operatorName,
-              stateStoreMetadata.storeName,
-              stateStoreMetadata.numPartitions,
-              if (batchIds.nonEmpty) batchIds.head else -1,
-              if (batchIds.nonEmpty) batchIds.last else -1,
-              v2.operatorPropertiesJson,
-              stateStoreMetadata.numColsPrefixKey
-            )
-          }
+      val operatorProperties = operatorStateMetadata match {
+        case _: OperatorStateMetadataV1 => ""
+        case v2: OperatorStateMetadataV2 => v2.operatorPropertiesJson
+      }
+      operatorStateMetadata.stateStoreInfo.map { stateStoreMetadata =>
+          StateMetadataTableEntry(operatorStateMetadata.operatorInfo.operatorId,
+          operatorStateMetadata.operatorInfo.operatorName,
+          stateStoreMetadata.storeName,
+          stateStoreMetadata.numPartitions,
+          if (batchIds.nonEmpty) batchIds.head else -1,
+          if (batchIds.nonEmpty) batchIds.last else -1,
+          operatorProperties,
+          stateStoreMetadata.numColsPrefixKey
+          )
       }
     }
   }.iterator

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
@@ -26,7 +26,6 @@ import org.apache.hadoop.fs.{Path, PathFilter}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
-import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, MapData}
 import org.apache.spark.sql.connector.catalog.{MetadataColumn, SupportsMetadataColumns, SupportsRead, Table, TableCapability, TableProvider}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReader, PartitionReaderFactory, Scan, ScanBuilder}
@@ -35,7 +34,7 @@ import org.apache.spark.sql.execution.datasources.v2.state.StateSourceOptions.PA
 import org.apache.spark.sql.execution.streaming.CheckpointFileManager
 import org.apache.spark.sql.execution.streaming.state.{OperatorStateMetadata, OperatorStateMetadataReader, OperatorStateMetadataV1, OperatorStateMetadataV2}
 import org.apache.spark.sql.sources.DataSourceRegister
-import org.apache.spark.sql.types.{DataType, IntegerType, LongType, MapType, StringType, StructType}
+import org.apache.spark.sql.types.{DataType, IntegerType, LongType, StringType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.SerializableConfiguration
@@ -47,13 +46,9 @@ case class StateMetadataTableEntry(
     numPartitions: Int,
     minBatchId: Long,
     maxBatchId: Long,
-    operatorProperties: Map[String, String],
+    operatorProperties: String,
     numColsPrefixKey: Int) {
   def toRow(): InternalRow = {
-    // create MapData from Map
-    val mapData: MapData = ArrayBasedMapData.apply(
-      operatorProperties.keys.map(UTF8String.fromString).toArray,
-      operatorProperties.values.map(UTF8String.fromString).toArray)
 
     new GenericInternalRow(
       Array[Any](operatorId,
@@ -62,7 +57,7 @@ case class StateMetadataTableEntry(
         numPartitions,
         minBatchId,
         maxBatchId,
-        mapData))
+        UTF8String.fromString(operatorProperties)))
   }
 }
 
@@ -75,7 +70,7 @@ object StateMetadataTableEntry {
       .add("numPartitions", IntegerType)
       .add("minBatchId", LongType)
       .add("maxBatchId", LongType)
-      .add("operatorProperties", MapType(StringType, StringType, valueContainsNull = false))
+      .add("operatorProperties", StringType)
   }
 }
 
@@ -217,7 +212,7 @@ class StateMetadataPartitionReader(
               stateStoreMetadata.numPartitions,
               if (batchIds.nonEmpty) batchIds.head else -1,
               if (batchIds.nonEmpty) batchIds.last else -1,
-              Map.empty[String, String],
+              "",
               stateStoreMetadata.numColsPrefixKey
             )
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -190,6 +190,8 @@ class IncrementalExecution(
   object WriteStatefulOperatorMetadataRule extends SparkPlanPartialRule {
     override val rule: PartialFunction[SparkPlan, SparkPlan] = {
       case stateStoreWriter: StateStoreWriter
+        // We only want to write the OperatorStateMetadata via this rule if
+        // we are in the first batch and the state format version is 1.
         if isFirstBatch && stateStoreWriter.operatorStateMetadataVersion == 1 =>
           val metadata = stateStoreWriter.operatorStateMetadata()
           val metadataWriter = new OperatorStateMetadataWriter(new Path(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -390,7 +390,7 @@ class MicroBatchExecution(
           currentBatchHasNewData,
           execCtx.executionPlan,
           execCtx.batchId,
-          Some(execCtx.previousContext)
+          execCtx.previousContext
         )
       } else {
         execCtx.finishNoExecutionTrigger(execCtx.batchId)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -386,7 +386,12 @@ class MicroBatchExecution(
       execCtx.carryOverExecStatsOnLatestExecutedBatch()
       // Must be outside reportTimeTaken so it is recorded
       if (execCtx.isCurrentBatchConstructed) {
-        execCtx.finishTrigger(currentBatchHasNewData, execCtx.executionPlan, execCtx.batchId)
+        execCtx.finishTrigger(
+          currentBatchHasNewData,
+          execCtx.executionPlan,
+          execCtx.batchId,
+          Some(execCtx.previousContext)
+        )
       } else {
         execCtx.finishNoExecutionTrigger(execCtx.batchId)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
@@ -269,6 +269,10 @@ abstract class ProgressContext(
       currentTriggerStartOffsets != null && currentTriggerEndOffsets != null &&
         currentTriggerLatestOffsets != null
     )
+    if (lastExecution.isFirstBatch) {
+      lastExecution.executedPlan.writeOperatorStateMetadata()
+    }
+
     currentTriggerEndTimestamp = triggerClock.getTimeMillis()
     val processingTimeMills = currentTriggerEndTimestamp - currentTriggerStartTimestamp
     assert(lastExecution != null, "executed batch should provide the information for execution.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
@@ -265,7 +265,7 @@ abstract class ProgressContext(
       sourceToNumInputRowsMap: Map[SparkDataStream, Long],
       lastExecution: IncrementalExecution,
       lastEpochId: Long,
-      previousExecution: Option[StreamExecutionContext]): Unit = {
+      previousExecution: Option[MicroBatchExecutionContext]): Unit = {
     assert(
       currentTriggerStartOffsets != null && currentTriggerEndOffsets != null &&
         currentTriggerLatestOffsets != null
@@ -389,7 +389,7 @@ abstract class ProgressContext(
       hasNewData: Boolean,
       lastExecution: IncrementalExecution,
       lastEpoch: Long,
-      previousContext: Option[StreamExecutionContext] = None): Unit = {
+      previousContext: Option[MicroBatchExecutionContext] = None): Unit = {
     val map: Map[SparkDataStream, Long] =
       if (hasNewData) extractSourceToNumInputRows(lastExecution) else Map.empty
     finishTrigger(hasNewData, map, lastExecution, lastEpoch, previousContext)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateVariableInfo.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateVariableInfo.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.streaming
+
+import org.json4s.{DefaultFormats, Formats, JValue}
+import org.json4s.JsonAST.{JBool, JString}
+import org.json4s.JsonDSL._
+
+// Enum to store the types of state variables we support
+sealed trait StateVariableType
+
+case object ValueState extends StateVariableType
+case object ListState extends StateVariableType
+case object MapState extends StateVariableType
+
+// This object is used to convert the state type from string to the corresponding enum
+object StateVariableType {
+  def withName(name: String): StateVariableType = name match {
+    case "ValueState" => ValueState
+    case "ListState" => ListState
+    case "MapState" => MapState
+    case _ => throw new IllegalArgumentException(s"Unknown state type: $name")
+  }
+}
+
+// This class is used to store the information about a state variable.
+// It is stored in operatorProperties for the TransformWithStateExec operator
+// to be able to validate that the State Variables are the same across restarts.
+class StateVariableInfo(
+   val stateName: String,
+   val stateType: StateVariableType,
+   val isTtlEnabled: Boolean
+ ) {
+  def jsonValue: JValue = {
+    ("stateName" -> JString(stateName)) ~
+      ("stateType" -> JString(stateType.toString)) ~
+      ("isTtlEnabled" -> JBool(isTtlEnabled))
+  }
+}
+
+// This object is used to convert the state variable information
+// from JSON to a list of StateVariableInfo
+object StateVariableInfo {
+  implicit val formats: Formats = DefaultFormats
+  def fromJson(json: Any): List[StateVariableInfo] = {
+    assert(json.isInstanceOf[List[_]], s"Expected List but got ${json.getClass}")
+    val stateVariables = json.asInstanceOf[List[Map[String, Any]]]
+    // Extract each JValue to StateVariableInfo
+    stateVariables.map { stateVariable =>
+      new StateVariableInfo(
+        stateVariable("stateName").asInstanceOf[String],
+        StateVariableType.withName(stateVariable("stateType").asInstanceOf[String]),
+        stateVariable("isTtlEnabled").asInstanceOf[Boolean]
+      )
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -69,6 +69,22 @@ class QueryInfoImpl(
   }
 }
 
+sealed trait StateVariableType
+
+case object ValueState extends StateVariableType
+case object ListState extends StateVariableType
+case object MapState extends StateVariableType
+
+class StateVariableInfo(
+    val stateName: String,
+    val stateType: StateVariableType,
+    val isTtlEnabled: Boolean
+) {
+  override def toString: String = {
+    s"StateVariableInfo(stateName=$stateName, stateType=$stateType, isTtlEnabled=$isTtlEnabled)"
+  }
+}
+
 /**
  * Class that provides a concrete implementation of a StatefulProcessorHandle. Note that we keep
  * track of valid transitions as various functions are invoked to track object lifecycle.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -21,10 +21,6 @@ import java.util.UUID
 
 import scala.collection.mutable
 
-import org.json4s.{DefaultFormats, Formats, JValue}
-import org.json4s.JsonAST.{JBool, JString}
-import org.json4s.JsonDSL._
-
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Encoder
@@ -70,52 +66,6 @@ class QueryInfoImpl(
 
   override def toString: String = {
     s"QueryInfo(queryId=$queryId, runId=$runId, batchId=$batchId)"
-  }
-}
-
-sealed trait StateVariableType
-
-case object ValueState extends StateVariableType
-case object ListState extends StateVariableType
-case object MapState extends StateVariableType
-
-object StateVariableType {
-  def withName(name: String): StateVariableType = name match {
-    case "ValueState" => ValueState
-    case "ListState" => ListState
-    case "MapState" => MapState
-    case _ => throw new IllegalArgumentException(s"Unknown state type: $name")
-  }
-}
-class StateVariableInfo(
-    val stateName: String,
-    val stateType: StateVariableType,
-    val isTtlEnabled: Boolean
-) {
-  override def toString: String = {
-    s"StateVariableInfo(stateName=$stateName, stateType=$stateType, isTtlEnabled=$isTtlEnabled)"
-  }
-
-  def jsonValue: JValue = {
-    ("stateName" -> JString(stateName)) ~
-      ("stateType" -> JString(stateType.toString)) ~
-      ("isTtlEnabled" -> JBool(isTtlEnabled))
-
-  }
-}
-
-object StateVariableInfo {
-  implicit val formats: Formats = DefaultFormats
-  def fromJson(json: Any): List[StateVariableInfo] = {
-    val stateVariables = json.asInstanceOf[List[Map[String, Any]]]
-    // Extract each JValue to StateVariableInfo
-    stateVariables.map { stateVariable =>
-      new StateVariableInfo(
-        stateVariable("stateName").asInstanceOf[String],
-        StateVariableType.withName(stateVariable("stateType").asInstanceOf[String]),
-        stateVariable("isTtlEnabled").asInstanceOf[Boolean]
-      )
-    }
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -96,8 +96,8 @@ class StatefulProcessorHandleImpl(
    */
   private[sql] val ttlStates: util.List[TTLState] = new util.ArrayList[TTLState]()
 
-  var stateVariables: mutable.ListBuffer[StateVariableInfo] =
-    mutable.ListBuffer.empty[StateVariableInfo]
+  private[sql] val stateVariables: util.List[StateVariableInfo] =
+    new util.ArrayList[StateVariableInfo]()
 
   private val BATCH_QUERY_ID = "00000000-0000-0000-0000-000000000000"
 
@@ -134,7 +134,7 @@ class StatefulProcessorHandleImpl(
       stateName: String,
       valEncoder: Encoder[T]): ValueState[T] = {
     verifyStateVarOperations("get_value_state")
-    stateVariables.append(new StateVariableInfo(stateName, ValueState, false))
+    stateVariables.add(new StateVariableInfo(stateName, ValueState, false))
     incrementMetric("numValueStateVars")
     val resultState = new ValueStateImpl[T](store, stateName, keyEncoder, valEncoder)
     resultState
@@ -145,7 +145,7 @@ class StatefulProcessorHandleImpl(
       valEncoder: Encoder[T],
       ttlConfig: TTLConfig): ValueState[T] = {
     verifyStateVarOperations("get_value_state")
-    stateVariables.append(new StateVariableInfo(stateName, ValueState, true))
+    stateVariables.add(new StateVariableInfo(stateName, ValueState, true))
     validateTTLConfig(ttlConfig, stateName)
 
     assert(batchTimestampMs.isDefined)
@@ -247,7 +247,7 @@ class StatefulProcessorHandleImpl(
 
   override def getListState[T](stateName: String, valEncoder: Encoder[T]): ListState[T] = {
     verifyStateVarOperations("get_list_state")
-    stateVariables.append(new StateVariableInfo(stateName, ListState, false))
+    stateVariables.add(new StateVariableInfo(stateName, ListState, false))
     incrementMetric("numListStateVars")
     val resultState = new ListStateImpl[T](store, stateName, keyEncoder, valEncoder)
     resultState
@@ -274,7 +274,7 @@ class StatefulProcessorHandleImpl(
       ttlConfig: TTLConfig): ListState[T] = {
 
     verifyStateVarOperations("get_list_state")
-    stateVariables.append(new StateVariableInfo(stateName, ListState, true))
+    stateVariables.add(new StateVariableInfo(stateName, ListState, true))
     validateTTLConfig(ttlConfig, stateName)
 
     assert(batchTimestampMs.isDefined)
@@ -291,7 +291,7 @@ class StatefulProcessorHandleImpl(
       userKeyEnc: Encoder[K],
       valEncoder: Encoder[V]): MapState[K, V] = {
     verifyStateVarOperations("get_map_state")
-    stateVariables.append(new StateVariableInfo(stateName, MapState, false))
+    stateVariables.add(new StateVariableInfo(stateName, MapState, false))
     incrementMetric("numMapStateVars")
     val resultState = new MapStateImpl[K, V](store, stateName, keyEncoder, userKeyEnc, valEncoder)
     resultState
@@ -303,7 +303,7 @@ class StatefulProcessorHandleImpl(
       valEncoder: Encoder[V],
       ttlConfig: TTLConfig): MapState[K, V] = {
     verifyStateVarOperations("get_map_state")
-    stateVariables.append(new StateVariableInfo(stateName, MapState, true))
+    stateVariables.add(new StateVariableInfo(stateName, MapState, true))
     validateTTLConfig(ttlConfig, stateName)
 
     assert(batchTimestampMs.isDefined)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -21,7 +21,8 @@ import java.util.UUID
 
 import scala.collection.mutable
 
-import org.json4s.JsonAST.{JBool, JString, JValue}
+import org.json4s.{DefaultFormats, Formats, JValue}
+import org.json4s.JsonAST.{JBool, JString}
 import org.json4s.JsonDSL._
 
 import org.apache.spark.TaskContext
@@ -78,6 +79,14 @@ case object ValueState extends StateVariableType
 case object ListState extends StateVariableType
 case object MapState extends StateVariableType
 
+object StateVariableType {
+  def withName(name: String): StateVariableType = name match {
+    case "ValueState" => ValueState
+    case "ListState" => ListState
+    case "MapState" => MapState
+    case _ => throw new IllegalArgumentException(s"Unknown state type: $name")
+  }
+}
 class StateVariableInfo(
     val stateName: String,
     val stateType: StateVariableType,
@@ -92,6 +101,21 @@ class StateVariableInfo(
       ("stateType" -> JString(stateType.toString)) ~
       ("isTtlEnabled" -> JBool(isTtlEnabled))
 
+  }
+}
+
+object StateVariableInfo {
+  implicit val formats: Formats = DefaultFormats
+  def fromJson(json: Any): List[StateVariableInfo] = {
+    val stateVariables = json.asInstanceOf[List[Map[String, Any]]]
+    // Extract each JValue to StateVariableInfo
+    stateVariables.map { stateVariable =>
+      new StateVariableInfo(
+        stateVariable("stateName").asInstanceOf[String],
+        StateVariableType.withName(stateVariable("stateType").asInstanceOf[String]),
+        stateVariable("isTtlEnabled").asInstanceOf[Boolean]
+      )
+    }
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -21,6 +21,9 @@ import java.util.UUID
 
 import scala.collection.mutable
 
+import org.json4s.JsonAST.{JBool, JString, JValue}
+import org.json4s.JsonDSL._
+
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Encoder
@@ -82,6 +85,13 @@ class StateVariableInfo(
 ) {
   override def toString: String = {
     s"StateVariableInfo(stateName=$stateName, stateType=$stateType, isTtlEnabled=$isTtlEnabled)"
+  }
+
+  def jsonValue: JValue = {
+    ("stateName" -> JString(stateName)) ~
+      ("stateType" -> JString(stateType.toString)) ~
+      ("isTtlEnabled" -> JBool(isTtlEnabled))
+
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -19,8 +19,6 @@ package org.apache.spark.sql.execution.streaming
 import java.util
 import java.util.UUID
 
-import scala.collection.mutable
-
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Encoder

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecutionContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecutionContext.scala
@@ -118,7 +118,7 @@ class ContinuousExecutionContext(
  */
 class MicroBatchExecutionContext(
     id: UUID,
-    runId: UUID,
+    val runId: UUID,
     name: String,
     triggerClock: Clock,
     sources: Seq[SparkDataStream],

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -106,9 +106,6 @@ case class TransformWithStateExec(
    * to write the metadata of the operator to the checkpoint file.
    */
   override def writeOperatorStateMetadata(): Unit = {
-    operatorProperties.value.foreach { case (key, value) =>
-      logError(s"### $key: $value")
-    }
     val metadata = operatorStateMetadata()
     val metadataWriter = new OperatorStateMetadataWriter(
       new Path(stateInfo.get.checkpointLocation,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -37,55 +37,6 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming._
 import org.apache.spark.util.{AccumulatorV2, CompletionIterator, SerializableConfiguration, Utils}
 
-// define state variable type enum with types VALUE, LIST, MAP
-sealed trait StateVariableType
-case object ValueState extends StateVariableType
-case object ListState extends StateVariableType
-case object MapState extends StateVariableType
-class StateVariableInfo(
-    val stateName: String,
-    val stateType: StateVariableType,
-    val isTtlEnabled: Boolean
-) {
-    override def toString: String = {
-      s"StateVariableInfo(stateName=$stateName, stateType=$stateType, isTtlEnabled=$isTtlEnabled)"
-    }
-}
-
-class OperatorProperties(initValue: Map[String, String] = Map.empty)
-  extends AccumulatorV2[Map[String, String], Map[String, String]] {
-
-  private var _value: Map[String, String] = initValue
-
-  override def isZero: Boolean = _value.isEmpty
-
-  override def copy(): AccumulatorV2[Map[String, String], Map[String, String]] = {
-    val newAcc = new OperatorProperties
-    newAcc._value = _value
-    newAcc
-  }
-
-  override def reset(): Unit = _value = Map.empty[String, String]
-
-  override def add(v: Map[String, String]): Unit = _value ++= v
-
-  override def merge(other: AccumulatorV2[Map[String, String], Map[String, String]]): Unit = {
-    _value ++= other.value
-  }
-
-  override def value: Map[String, String] = _value
-}
-
-object OperatorProperties {
-  def create(
-      sc: SparkContext,
-      name: String,
-      initValue: Map[String, String] = Map.empty): OperatorProperties = {
-    val acc = new OperatorProperties(initValue)
-    acc.register(sc, name = Some(name))
-    acc
-  }
-}
 /**
  * Physical operator for executing `TransformWithState`
  *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -35,7 +34,7 @@ import org.apache.spark.sql.execution.streaming.TransformWithStateKeyValueRowSch
 import org.apache.spark.sql.execution.streaming.state._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming._
-import org.apache.spark.util.{AccumulatorV2, CompletionIterator, SerializableConfiguration, Utils}
+import org.apache.spark.util.{CompletionIterator, SerializableConfiguration, Utils}
 
 /**
  * Physical operator for executing `TransformWithState`

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.execution.streaming
 import java.util.UUID
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
 import org.apache.hadoop.fs.Path
 import org.json4s.{DefaultFormats, JArray, JString}
 import org.json4s.JsonAST.JValue
@@ -352,7 +354,8 @@ case class TransformWithStateExec(
         }
       }
       operatorProperties.add(Map
-        ("stateVariables" -> JArray(processorHandle.stateVariables.map(_.jsonValue).toList)))
+        ("stateVariables" -> JArray(processorHandle.stateVariables.
+          asScala.map(_.jsonValue).toList)))
       setStoreMetrics(store)
       setOperatorMetrics()
       statefulProcessor.close()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -112,7 +112,7 @@ case class TransformWithStateExec(
       session.sqlContext.sessionState.newHadoopConf()
     )
     metadataWriter.write(metadata)
-    children.foreach(_.writeOperatorStateMetadata())
+    super.writeOperatorStateMetadata()
   }
 
   override def shouldRunAnotherBatch(newInputWatermark: Long): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
@@ -158,9 +158,12 @@ class OperatorStateMetadataReader(stateCheckpointPath: Path, hadoopConf: Configu
       new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
     try {
       val versionStr = inputReader.readLine()
-      val version = MetadataVersionUtil.validateVersion(versionStr, 1)
-      assert(version == 1)
-      OperatorStateMetadataV1.deserialize(inputReader)
+      val version = MetadataVersionUtil.validateVersion(versionStr, 2)
+      assert(version == 1 || version == 2)
+      version match {
+        case 1 => OperatorStateMetadataV1.deserialize(inputReader)
+        case 2 => OperatorStateMetadataV2.deserialize(inputReader)
+      }
     } finally {
       inputStream.close()
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
@@ -19,7 +19,9 @@ package org.apache.spark.sql.execution.streaming.state
 
 import java.io.{BufferedReader, InputStreamReader}
 import java.nio.charset.StandardCharsets
+
 import scala.reflect.ClassTag
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataOutputStream, Path}
 import org.json4s.{Formats, NoTypeHints}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
@@ -57,6 +57,10 @@ case class OperatorInfoV1(operatorId: Long, operatorName: String) extends Operat
 
 trait OperatorStateMetadata {
   def version: Int
+
+  def operatorInfo: OperatorInfo
+
+  def stateStoreInfo: Array[StateStoreMetadataV1]
 }
 
 object OperatorStateMetadata {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
@@ -115,7 +115,7 @@ object OperatorProperties {
 case class OperatorStateMetadataV2(
     operatorInfo: OperatorInfoV1,
     stateStoreInfo: Array[StateStoreMetadataV1],
-    operatorProperties: String) extends OperatorStateMetadata {
+    operatorPropertiesJson: String) extends OperatorStateMetadata {
   override def version: Int = 2
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
@@ -110,6 +110,8 @@ object OperatorProperties {
   }
 }
 
+// operatorProperties is an arbitrary JSON formatted string that contains
+// any properties that we would want to store for a particular operator.
 case class OperatorStateMetadataV2(
     operatorInfo: OperatorInfoV1,
     stateStoreInfo: Array[StateStoreMetadataV1],
@@ -141,7 +143,7 @@ object OperatorStateMetadataV2 {
 
   @scala.annotation.nowarn
   private implicit val manifest = Manifest
-    .classType[OperatorStateMetadataV1](implicitly[ClassTag[OperatorStateMetadataV2]].runtimeClass)
+    .classType[OperatorStateMetadataV2](implicitly[ClassTag[OperatorStateMetadataV2]].runtimeClass)
 
   def deserialize(in: BufferedReader): OperatorStateMetadata = {
     Serialization.read[OperatorStateMetadataV2](in)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
@@ -25,6 +25,7 @@ import scala.reflect.ClassTag
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataOutputStream, Path}
 import org.json4s.{Formats, NoTypeHints}
+import org.json4s.JsonAST.JValue
 import org.json4s.jackson.Serialization
 
 import org.apache.spark.SparkContext
@@ -74,35 +75,35 @@ case class OperatorStateMetadataV1(
  * available on the driver at the time of planning, and will only be known from
  * the executor side.
  */
-class OperatorProperties(initValue: Map[String, String] = Map.empty)
-  extends AccumulatorV2[Map[String, String], Map[String, String]] {
+class OperatorProperties(initValue: Map[String, JValue] = Map.empty)
+  extends AccumulatorV2[Map[String, JValue], Map[String, JValue]] {
 
-  private var _value: Map[String, String] = initValue
+  private var _value: Map[String, JValue] = initValue
 
   override def isZero: Boolean = _value.isEmpty
 
-  override def copy(): AccumulatorV2[Map[String, String], Map[String, String]] = {
+  override def copy(): AccumulatorV2[Map[String, JValue], Map[String, JValue]] = {
     val newAcc = new OperatorProperties
     newAcc._value = _value
     newAcc
   }
 
-  override def reset(): Unit = _value = Map.empty[String, String]
+  override def reset(): Unit = _value = Map.empty[String, JValue]
 
-  override def add(v: Map[String, String]): Unit = _value ++= v
+  override def add(v: Map[String, JValue]): Unit = _value ++= v
 
-  override def merge(other: AccumulatorV2[Map[String, String], Map[String, String]]): Unit = {
+  override def merge(other: AccumulatorV2[Map[String, JValue], Map[String, JValue]]): Unit = {
     _value ++= other.value
   }
 
-  override def value: Map[String, String] = _value
+  override def value: Map[String, JValue] = _value
 }
 
 object OperatorProperties {
   def create(
       sc: SparkContext,
       name: String,
-      initValue: Map[String, String] = Map.empty): OperatorProperties = {
+      initValue: Map[String, JValue] = Map.empty): OperatorProperties = {
     val acc = new OperatorProperties(initValue)
     acc.register(sc, name = Some(name))
     acc
@@ -112,7 +113,7 @@ object OperatorProperties {
 case class OperatorStateMetadataV2(
     operatorInfo: OperatorInfoV1,
     stateStoreInfo: Array[StateStoreMetadataV1],
-    operatorProperties: Map[String, String]) extends OperatorStateMetadata {
+    operatorProperties: String) extends OperatorStateMetadata {
   override def version: Int = 2
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -176,6 +176,8 @@ trait StateStoreWriter extends StatefulOperator with PythonSQLMetrics { self: Sp
     )
   }
 
+  def operatorStateMetadataVersion: Int = 1
+
   /** Records the duration of running `body` for the next query progress update. */
   protected def timeTakenMs(body: => Unit): Long = Utils.timeTakenMs(body)._2
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -368,7 +368,7 @@ class TransformWithStateSuite extends StateStoreMetricsTest
     }
   }
 
-  test("state reader") {
+  test("verify that operatorProperties contain all stateVariables") {
     withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
       classOf[RocksDBStateStoreProvider].getName) {
       withTempDir { chkptDir =>
@@ -413,14 +413,13 @@ class TransformWithStateSuite extends StateStoreMetricsTest
           StopStream
         )
 
-        val stateReadDf = spark.read
+        val df = spark.read
           .format("state-metadata")
           .option(StateSourceOptions.PATH, chkptDir.getAbsolutePath)
           // skip version and operator ID to test out functionalities
           .load()
 
-        // print out all the contents of the stateReadDf
-        stateReadDf.show()
+        df.show()
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -428,15 +428,10 @@ class TransformWithStateSuite extends StateStoreMetricsTest
         assert(map("timeMode") === "ProcessingTime")
         assert(map("outputMode") === "Update")
 
-        // TODO: Find a way to verify the stateVariables, need to deserialize from JArray
-//       // get "stateVariables" as list and cast this list as a collection of StateVariableInfo
-//        val stateVariables = map("stateVariables").asInstanceOf[JArray].arr
-//        val stateVariableInfos = stateVariables.map { sv =>
-//
-//        }
-//
-//        // check that all stateVariables are present in operatorProperties
-//        assert(stateVariableInfos.size === 1)
+        val stateVariableInfos = StateVariableInfo.fromJson(
+          map("stateVariables"))
+        assert(stateVariableInfos.size === 1)
+        assert(stateVariableInfos.exists(_.stateName === "countState"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -414,7 +414,7 @@ class TransformWithStateSuite extends StateStoreMetricsTest
         )
 
         val stateReadDf = spark.read
-          .format("statestore")
+          .format("state-metadata")
           .option(StateSourceOptions.PATH, chkptDir.getAbsolutePath)
           // skip version and operator ID to test out functionalities
           .load()

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -416,10 +416,27 @@ class TransformWithStateSuite extends StateStoreMetricsTest
         val df = spark.read
           .format("state-metadata")
           .option(StateSourceOptions.PATH, chkptDir.getAbsolutePath)
-          // skip version and operator ID to test out functionalities
           .load()
 
         df.show()
+
+        val propsString = df.select("operatorProperties").
+          collect().head.getString(0)
+
+        val map = TransformWithStateExec.
+          deserializeOperatorProperties(propsString)
+        assert(map("timeMode") === "ProcessingTime")
+        assert(map("outputMode") === "Update")
+
+        // TODO: Find a way to verify the stateVariables, need to deserialize from JArray
+//       // get "stateVariables" as list and cast this list as a collection of StateVariableInfo
+//        val stateVariables = map("stateVariables").asInstanceOf[JArray].arr
+//        val stateVariableInfos = stateVariables.map { sv =>
+//
+//        }
+//
+//        // check that all stateVariables are present in operatorProperties
+//        assert(stateVariableInfos.size === 1)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -418,8 +418,6 @@ class TransformWithStateSuite extends StateStoreMetricsTest
           .option(StateSourceOptions.PATH, chkptDir.getAbsolutePath)
           .load()
 
-        df.show()
-
         val propsString = df.select("operatorProperties").
           collect().head.getString(0)
 
@@ -431,7 +429,10 @@ class TransformWithStateSuite extends StateStoreMetricsTest
         val stateVariableInfos = StateVariableInfo.fromJson(
           map("stateVariables"))
         assert(stateVariableInfos.size === 1)
-        assert(stateVariableInfos.exists(_.stateName === "countState"))
+        val stateVariableInfo = stateVariableInfos.head
+        assert(stateVariableInfo.stateName === "countState")
+        assert(stateVariableInfo.isTtlEnabled === false)
+        assert(stateVariableInfo.stateType === ValueState)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -419,7 +419,7 @@ class TransformWithStateSuite extends StateStoreMetricsTest
           // skip version and operator ID to test out functionalities
           .load()
 
-//        // print out all the contents of the stateReadDf
+        // print out all the contents of the stateReadDf
         stateReadDf.show()
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Introducing the `OperatorStateMetadataV2` class for the TransformWithState operator. This class, in addition to storing general operator information, also stores a map of arbitrary operator properties. We use this map to capture column family information that is not available from the driver, and is only available on the executors. Executors relay this information back to the driver via an Accumulator.

In this change, I simply want to deal with writing the OperatorStateMetadata info out to the file. We will deal with eviction, deduplication, and failure scenarios in future PRs. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
These changes are needed as a part of the State Reader integration with the TransformWithState operator. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Via unit test. We are verifying that the information from operatorProperties that we collect from the executor are propagated correctly to the driver, and that any information is written appropriately. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No